### PR TITLE
Support hpool miner status

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -98,7 +98,7 @@ module.exports = class Config {
         if (!upstream.type && !upstream.url) {
           Config.logErrorAndExit(`Proxy ${proxy.name}: Upstream ${upstream.name}: No url defined!`);
         }
-        if (!upstream.targetDL && !upstream.submitProbability) {
+        if (upstream.type !== 'hpool' && !upstream.targetDL && !upstream.submitProbability) {
           Config.logErrorAndExit(`Proxy ${proxy.name}: Upstream ${upstream.name}: No targetDL or submitProbability defined!`);
         }
         if ((upstreamTypesWithAccountKey.indexOf(upstream.type) !== -1) && !upstream.accountKeyForAccountId && !upstream.accountKey) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -66,6 +66,11 @@ module.exports = class Config {
   }
 
   validateConfig() {
+    const upstreamTypesWithAccountKey = [
+      'hdpool',
+      'hdpool-eco',
+      'hpool',
+    ];
     const validListenAddrExists = this.config.listenAddr && this.config.listenAddr.split(':').length === 2;
     if (!validListenAddrExists) {
       Config.logErrorAndExit('No valid listenAddr specified!');
@@ -96,7 +101,7 @@ module.exports = class Config {
         if (!upstream.targetDL && !upstream.submitProbability) {
           Config.logErrorAndExit(`Proxy ${proxy.name}: Upstream ${upstream.name}: No targetDL or submitProbability defined!`);
         }
-        if (upstream.type === 'hdpool' && !upstream.accountKeyForAccountId && !upstream.accountKey) {
+        if ((upstreamTypesWithAccountKey.indexOf(upstream.type) !== -1) && !upstream.accountKeyForAccountId && !upstream.accountKey) {
           Config.logErrorAndExit(`Proxy ${proxy.name}: Upstream ${upstream.name}: No accountKey defined!`);
         }
       });

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -4,6 +4,7 @@ const moment = require('moment');
 const eventBus = require('./services/event-bus');
 const GenericUpstream = require('./upstream/generic');
 const HDPool = require('./upstream/hdpool');
+const HPool = require('./upstream/hpool');
 const BurstGrpc = require('./upstream/burst-grpc');
 const SocketIoProxy = require('./upstream/socketio-proxy');
 const Submission = require('./submission');
@@ -19,6 +20,8 @@ class Proxy {
         return BurstGrpc;
       case 'proxy':
         return SocketIoProxy;
+      case 'hpool':
+        return HPool;
       default:
         return GenericUpstream;
     }

--- a/lib/upstream/hpool.js
+++ b/lib/upstream/hpool.js
@@ -1,0 +1,36 @@
+const superagent = require('superagent');
+const eventBus = require('../services/event-bus');
+const version = require('../version');
+const GenericUpstream = require('./generic');
+
+class HPool extends GenericUpstream {
+  async init() {
+    this.upstreamConfig.url = 'https://bhd.hpool.com';
+    this.isBHD = true;
+    await super.init();
+    setInterval(this.updateMinerStatus.bind(this), 60 * 1000);
+  }
+
+  async updateMinerStatus() {
+    try {
+      const userAgent = `BHD-Burst-Proxy ${version}`;
+      let request = superagent.post(`${this.upstreamConfig.url}/proxy/uploadminerstatus`)
+        .send([{
+          'X-Account': this.upstreamConfig.accountKey,
+          'X-Capacity': this.totalCapacity,
+          'X-ClientIP': '127.0.0.1',
+          'X-Miner': userAgent,
+          'X-Minername': this.upstreamConfig.minerName || this.defaultMinerName,
+        }])
+        .set('User-Agent', userAgent)
+        .set('X-Proxy', userAgent)
+        .set('X-Proxyname', this.upstreamConfig.minerName || this.defaultMinerName);
+
+      await request.retry(3);
+    } catch (err) {
+      eventBus.publish('log/error', `${this.fullUpstreamNameLogs} | Error: ${err.message}`);
+    }
+  }
+}
+
+module.exports = HPool;

--- a/lib/upstream/hpool.js
+++ b/lib/upstream/hpool.js
@@ -6,7 +6,9 @@ const GenericUpstream = require('./generic');
 class HPool extends GenericUpstream {
   async init() {
     this.upstreamConfig.url = 'https://bhd.hpool.com';
-    this.upstreamConfig.targetDL = 86400;
+    if (!this.upstreamConfig.targetDL) {
+      this.upstreamConfig.targetDL = 86400;
+    }
     if (!this.upstreamConfig.sendTargetDL) {
       this.upstreamConfig.sendTargetDL = 31536000;
     }

--- a/lib/upstream/hpool.js
+++ b/lib/upstream/hpool.js
@@ -6,6 +6,11 @@ const GenericUpstream = require('./generic');
 class HPool extends GenericUpstream {
   async init() {
     this.upstreamConfig.url = 'https://bhd.hpool.com';
+    this.upstreamConfig.targetDL = 86400;
+    if (!this.upstreamConfig.sendTargetDL) {
+      this.upstreamConfig.sendTargetDL = 31536000;
+    }
+    this.upstreamConfig.mode = 'pool';
     this.isBHD = true;
     await super.init();
     setInterval(this.updateMinerStatus.bind(this), 60 * 1000);


### PR DESCRIPTION
This PR adds hpool as a upstream type with a fixed url. It adds support for uploading miner status which seems to be required by hpool in the future: https://bhd.hpool.com/news/5cc1a87c5333e70348d65d74

Closes #210 